### PR TITLE
add some excludes

### DIFF
--- a/common-excludes.js
+++ b/common-excludes.js
@@ -34,6 +34,8 @@ module.exports = class CommonExcludes {
         '*circle.yml',
         '*travis.yml',
         '*.md',
+        '*.apib',
+        '.vscode/**',
         'package-lock.json',
         '.npm-upgrade.json',
         'sonar-project.properties',

--- a/common-excludes.js
+++ b/common-excludes.js
@@ -47,6 +47,7 @@ module.exports = class CommonExcludes {
         'docs/**',
         'test/**',
         'tests/**',
+        'CODEOWNERS',
         // aws-sdk is included in Lambda
         'node_modules/**/aws-sdk/**',
         // common things that node_modules fail to .npmignore


### PR DESCRIPTION
Adding excludes for:
- `*.apib` [apiary](https://apiary.io) api blueprint specification file. Commonly used to specify contracts for iOS / android / web front end devs to work agains.
- `.vscode/**` vscode editor creates things like debug profiles in this dir that you may want to check in and share but not package.