### PR TITLE
Add GitLab CI configuration to the excluded files

### DIFF
--- a/common-excludes.js
+++ b/common-excludes.js
@@ -33,6 +33,7 @@ module.exports = class CommonExcludes {
         '.circleci/**',
         '*circle.yml',
         '*travis.yml',
+        '.gitlab-ci.yml',
         '*.md',
         '*.apib',
         '.vscode/**',


### PR DESCRIPTION
GitLab CI/CD pipelines are configured using a YAML file called `.gitlab-ci.yml` within each project.

https://docs.gitlab.com/ee/ci/yaml/