### PR TITLE
Stop removing /docs/ from node_modules

### DIFF
--- a/common-excludes.js
+++ b/common-excludes.js
@@ -66,7 +66,6 @@ module.exports = class CommonExcludes {
         'node_modules/**/*.html',
         'node_modules/**/test/**',
         'node_modules/**/tests/**',
-        'node_modules/**/docs/**',
         'node_modules/**/examples/**',
         'node_modules/**/coverage/**',
         'node_modules/**/.nyc_output/**',


### PR DESCRIPTION
In #15 it was suggested to replace `**/docs/**` with `*.md`, `*.txt` and so on, but all these extensions are already being removed.

Fixes #15